### PR TITLE
Implementation of linktoAnimated functionality

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
                 src: [
                     'src/js/animated-container-view.js',
                     'src/js/animated-outlet-helper.js',
+                    'src/js/animated-linkto-helper.js',
                     'src/js/route.js',
                     'src/js/controller-mixin.js',
                     'src/js/effects/*.js'

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ in the `<head>`.
 </head>
 <body>
     <!-- Add your Handlebars templates here  -->
-    
+
     <script src="/vendor/jquery-1.9.0.js"></script>
     <script src="/vendor/handlebars-1.0.rc.3.js"></script>
     <script src="/vendor/ember.js"></script>
@@ -69,6 +69,26 @@ App.ApplicationRoute = Ember.Route.extend({
 });
 ```
 
+### Use `linkToAnimated` instead of `linkTo`
+
+When you want to use the animations from your Handlebars templates, you can use `linkToAnimated`. The syntax  for `linkToAnimated`is:
+
+```handlebars
+{{#linkToAnimated invoices.show animations="main:slideLeft" invoice}}
+```
+
+Where:
+- `invoices.show` is the route
+- `invoice` is the model
+- `main:slideLeft` is the animation
+
+When you are not using a model, the syntax is:
+
+```handlebars
+{{#linkToAnimated index animations="main:fade"}}Introduction{{/linkToAnimated}}
+```
+
+
 There are `*Animated` versions of all the different ways you can transition between routes:
 
 | Class | Normal method | Animated method |
@@ -79,7 +99,7 @@ There are `*Animated` versions of all the different ways you can transition betw
 | `Ember.Controller` | `replaceRoute(name, model)` | `replaceRouteAnimated(name, animations, model)` |
 
 You can also programmatically enqueue an animation for an outlet. A good example is when manually manipulating the `history`.
- 
+
 ```javascript
 App.ApplicationRoute = Ember.Route.extend({
     goBack: function(invoice) {
@@ -107,7 +127,7 @@ That's all it takes!
 You can use the following effects:
 
 | Effect name | Description |
-| ----------- | ----------- | 
+| ----------- | ----------- |
 | `fade` | The old view will be faded out, revealing the new view underneath it. Uses CSS transitions. |
 | `flip` | Using CSS3 to perform a 3D flip. |
 | `slideUp` | A slide animation where the views slide towards the top side of the screen. Uses CSS transitions. |
@@ -138,7 +158,7 @@ If you experience issues in any browser, please [file an issue](https://github.c
 - The `{{animatedOutlet}}` helper should be contained in an element that has `position: relative`. The outlet element is
   automatically absolutely positioned (set to top:0 and left:0) and will automatically size itself to be 100% width and
   100% height of the parent.
-- The animations use CSS transitions. There is no fallback for older browsers (yet).  
+- The animations use CSS transitions. There is no fallback for older browsers (yet).
 - Pressing the browser's back button will not perform any animation, unless you tap into the Ember code that handles
   the `popstate`/`hashchange` event.
 
@@ -156,7 +176,7 @@ Run `npm install` from the project directory to install dependencies.
 
 ### Building
 
-You can build the project simply by running `grunt` in your terminal. If you want to let Grunt watch your files, so it 
+You can build the project simply by running `grunt` in your terminal. If you want to let Grunt watch your files, so it
 automatically builds every time you change something, you can run `grunt watch`.
 
 The build process will place the files `ember-animated-outlet.js`, `ember-animated-outlet.min.js` and
@@ -184,5 +204,5 @@ The test suite uses [QUnit](http://qunitjs.com/).
 - Option to ignore all animations to allow users who don't like it to disable it.
 - Tests
     - Is there a better way than to use `setTimeout` to wait for animations to finish?
-- Write missing jsdoc for some classes 
+- Write missing jsdoc for some classes
 - Documentation of using Ember.AnimatedContainerView programmatically

--- a/src/js/animated-linkto-helper.js
+++ b/src/js/animated-linkto-helper.js
@@ -1,0 +1,101 @@
+/**
+@module ember
+@submodule ember-routing
+*/
+
+var get = Ember.get, set = Ember.set;
+
+Ember.onLoad('Ember.Handlebars', function(Handlebars) {
+  var resolveParams = Ember.Router.resolveParams,
+      isSimpleClick = Ember.ViewUtils.isSimpleClick;
+
+  function fullRouteName(router, name) {
+    if (!router.hasRoute(name)) {
+      name = name + '.index';
+    }
+
+    return name;
+  }
+
+  function resolvedPaths(options) {
+    var types = options.options.types.slice(1),
+        data = options.options.data;
+
+    return resolveParams(options.context, options.params, { types: types, data: data });
+  }
+
+  function args(linkView, router, route) {
+    var passedRouteName = route || linkView.namedRoute, routeName;
+
+    routeName = fullRouteName(router, passedRouteName);
+    Ember.assert("The route " + passedRouteName + " was not found", router.hasRoute(routeName));
+
+    var ret = [ routeName ];
+
+    animations = linkView.parameters.animations;
+
+    return ret.concat(animations, resolvedPaths(linkView.parameters));
+  }
+
+
+  /**
+    Renders a link to the supplied route using animation.
+
+    @class AnimatedLinkView
+    @namespace Ember
+    @extends Ember.LinkView
+  **/
+  var AnimatedLinkView = Ember.AnimatedLinkView = Ember.LinkView.extend({
+    click: function(event) {
+      if (!isSimpleClick(event)) { return true; }
+
+      event.preventDefault();
+      if (this.bubbles === false) { event.stopPropagation(); }
+
+      var router = this.get('router');
+      var route = this.get('container').lookup('route:' + this.get('namedRoute'));
+
+      if (this.get('replace')) {
+        route.replaceWithAnimated.apply(router, args(this, router));
+      } else {
+        route.transitionToAnimated.apply(router, args(this, router));
+      }
+    }
+  });
+
+  AnimatedLinkView.toString = function() { return "AnimatedLinkView"; };
+
+  /**
+    @method linkToAnimated
+    @for Ember.Handlebars.helpers
+    @param {String} routeName
+    @param {Object} [context]*
+    @return {String} HTML string
+  */
+  Ember.Handlebars.registerHelper('linkToAnimated', function(name) {
+    var options = [].slice.call(arguments, -1)[0];
+    var params = [].slice.call(arguments, 1, -1);
+    var hash = options.hash;
+
+    Ember.assert("linkToAnimated must contain animations", typeof(hash.animations) == 'string')
+    var re = /\s*([a-z]+)\s*:\s*([a-z]+)/gi;
+    var animations = {};
+    while (match = re.exec(hash.animations)) {
+      animations[match[1]] = match[2];
+    }
+    delete(hash.animations)
+    hash.namedRoute = name;
+    hash.currentWhen = hash.currentWhen || name;
+
+    hash.parameters = {
+      context: this,
+      options: options,
+      animations: animations,
+      params: params
+    };
+
+    return Ember.Handlebars.helpers.view.call(this, AnimatedLinkView, options);
+  });
+
+});
+

--- a/tests/animated-linkto-helper.js
+++ b/tests/animated-linkto-helper.js
@@ -1,0 +1,423 @@
+/*
+
+These tests are a shameless copy of the tests for linkTo helper of Ember.js
+
+*/
+var Router, App, AppView, templates, router, eventDispatcher, container;
+var get = Ember.get, set = Ember.set;
+
+function bootApplication() {
+  router = container.lookup('router:main');
+  Ember.run(App, 'advanceReadiness');
+}
+
+// IE includes the host name
+function normalizeUrl(url) {
+  return url.replace(/https?:\/\/[^\/]+/,'');
+}
+
+function compile(template) {
+  return Ember.Handlebars.compile(template);
+}
+
+module("The {{linkToAnimated}} helper", {
+  setup: function() {
+    Ember.run(function() {
+      App = Ember.Application.create({
+        name: "App",
+        rootElement: '#qunit-fixture'
+      });
+
+      App.deferReadiness();
+
+      App.Router.reopen({
+        location: 'none'
+      });
+
+      Router = App.Router;
+
+      Ember.TEMPLATES.app = Ember.Handlebars.compile("{{outlet}}");
+      Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkToAnimated about id='about-link' animations='main:fade'}}About{{/linkToAnimated}}{{#linkToAnimated index id='self-link' animations='main:fade'}}Self{{/linkToAnimated}}");
+      Ember.TEMPLATES.about = Ember.Handlebars.compile("<h3>About</h3>{{#linkToAnimated index id='home-link' animations='main:fade'}}Home{{/linkToAnimated}}{{#linkToAnimated about id='self-link' animations='main:fade'}}Self{{/linkToAnimated}}");
+      Ember.TEMPLATES.item = Ember.Handlebars.compile("<h3>Item</h3><p>{{name}}</p>{{#linkToAnimated index id='home-link' animations='main:fade'}}Home{{/linkToAnimated}}");
+
+      AppView = Ember.View.extend({
+        templateName: 'app'
+      });
+
+      container = App.__container__;
+
+      container.register('view:app');
+      container.register('router:main', Router);
+    });
+  },
+
+  teardown: function() {
+    Ember.run(function() { App.destroy(); });
+  }
+});
+
+test("moves into the named route", function() {
+  Router.map(function(match) {
+    this.route("about");
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('h3:contains(Home)', '#qunit-fixture').length, 1, "The home template was rendered");
+  equal(Ember.$('#self-link.active', '#qunit-fixture').length, 1, "The self-link was rendered with active class");
+  equal(Ember.$('#about-link:not(.active)', '#qunit-fixture').length, 1, "The other link was rendered without active class");
+
+  Ember.run(function() {
+    Ember.$('#about-link', '#qunit-fixture').click();
+  });
+
+  equal(Ember.$('h3:contains(About)', '#qunit-fixture').length, 1, "The about template was rendered");
+  equal(Ember.$('#self-link.active', '#qunit-fixture').length, 1, "The self-link was rendered with active class");
+  equal(Ember.$('#home-link:not(.active)', '#qunit-fixture').length, 1, "The other link was rendered without active class");
+});
+
+test("supports URL replacement", function() {
+  var setCount = 0,
+      replaceCount = 0;
+
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkToAnimated about id='about-link' animations='main:fade' replace=true}}About{{/linkToAnimated}}");
+
+  Router.reopen({
+    location: Ember.NoneLocation.createWithMixins({
+      setURL: function(path) {
+        setCount++;
+        set(this, 'path', path);
+      },
+
+      replaceURL: function(path) {
+        replaceCount++;
+        set(this, 'path', path);
+      }
+    })
+  });
+
+  Router.map(function() {
+    this.route("about");
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(setCount, 0, 'precond: setURL has not been called');
+  equal(replaceCount, 0, 'precond: replaceURL has not been called');
+
+  Ember.run(function() {
+    Ember.$('#about-link', '#qunit-fixture').click();
+  });
+
+  equal(setCount, 0, 'setURL should not be called');
+  equal(replaceCount, 1, 'replaceURL should be called once');
+});
+
+test("asserts when no animations given", function() {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkToAnimated about}}About{{/linkToAnimated}}{{#linkToAnimated index id='self-link' animations='main:fade' activeClass='zomg-active'}}Self{{/linkToAnimated}}");
+
+  Router.map(function() {
+    this.route("about");
+  });
+
+  throws(function() {
+    bootApplication();
+  }, /must contain animations/, "linkToAnimated must contain animations");
+});
+
+
+test("passes when empty animations given", function() {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkToAnimated about animations=''}}About{{/linkToAnimated}}{{#linkToAnimated index id='self-link' animations='main:fade' activeClass='zomg-active'}}Self{{/linkToAnimated}}");
+
+  Router.map(function() {
+    this.route("about");
+  });
+  bootApplication();
+  ok(true) ; // Nothing to test, just beeïng here is enough
+
+});
+
+
+test("supports a custom activeClass", function() {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkToAnimated about id='about-link' animations='main:fade'}}About{{/linkToAnimated}}{{#linkToAnimated index id='self-link' animations='main:fade' activeClass='zomg-active'}}Self{{/linkToAnimated}}");
+
+  Router.map(function() {
+    this.route("about");
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('h3:contains(Home)', '#qunit-fixture').length, 1, "The home template was rendered");
+  equal(Ember.$('#self-link.zomg-active', '#qunit-fixture').length, 1, "The self-link was rendered with active class");
+  equal(Ember.$('#about-link:not(.active)', '#qunit-fixture').length, 1, "The other link was rendered without active class");
+});
+
+test("supports leaving off .index for nested routes", function() {
+  Router.map(function() {
+    this.resource("about", function() {
+      this.route("item");
+    });
+  });
+
+  Ember.TEMPLATES.about = compile("<h1>About</h1>{{outlet}}");
+  Ember.TEMPLATES['about/index'] = compile("<div id='index'>Index</div>");
+  Ember.TEMPLATES['about/item'] = compile("<div id='item'>{{#linkToAnimated 'about' animations='main:fade'}}About{{/linkToAnimated}}</div>");
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/about/item");
+  });
+
+  equal(Ember.$('#item a', '#qunit-fixture').attr('href'), '/about');
+});
+
+test("supports custom, nested, currentWhen", function() {
+  Router.map(function(match) {
+    this.resource("index", { path: "/" }, function() {
+      this.route("about");
+    });
+
+    this.route("item");
+  });
+
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{outlet}}");
+  Ember.TEMPLATES['index/about'] = Ember.Handlebars.compile("{{#linkToAnimated item id='other-link' animations='main:fade' currentWhen='index'}}ITEM{{/linkToAnimated}}");
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/about");
+  });
+
+  equal(Ember.$('#other-link.active', '#qunit-fixture').length, 1, "The link is active since currentWhen is a parent route");
+});
+
+test("defaults to bubbling", function() {
+  Ember.TEMPLATES.about = Ember.Handlebars.compile("<div {{action 'hide'}}>{{#linkToAnimated 'about.contact' animations='main:fade' id='about-contact'}}About{{/linkToAnimated}}</div>{{outlet}}");
+  Ember.TEMPLATES['about/contact'] = Ember.Handlebars.compile("<h1 id='contact'>Contact</h1>");
+
+  Router.map(function() {
+    this.resource("about", function() {
+      this.route("contact");
+    });
+  });
+
+  var hidden = 0;
+
+  App.AboutRoute = Ember.Route.extend({
+    events: {
+      hide: function() {
+        hidden++;
+      }
+    }
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/about");
+  });
+
+  Ember.run(function() {
+    Ember.$('#about-contact', '#qunit-fixture').click();
+  });
+
+  equal(Ember.$("#contact", "#qunit-fixture").text(), "Contact", "precond - the link worked");
+
+  equal(hidden, 1, "The link bubbles");
+});
+
+test("supports bubbles=false", function() {
+  Ember.TEMPLATES.about = Ember.Handlebars.compile("<div {{action 'hide'}}>{{#linkToAnimated 'about.contact' animations='main:fade' id='about-contact' bubbles=false}}About{{/linkToAnimated}}</div>{{outlet}}");
+  Ember.TEMPLATES['about/contact'] = Ember.Handlebars.compile("<h1 id='contact'>Contact</h1>");
+
+  Router.map(function() {
+    this.resource("about", function() {
+      this.route("contact");
+    });
+  });
+
+  var hidden = 0;
+
+  App.AboutRoute = Ember.Route.extend({
+    events: {
+      hide: function() {
+        hidden++;
+      }
+    }
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/about");
+  });
+
+  Ember.run(function() {
+    Ember.$('#about-contact', '#qunit-fixture').click();
+  });
+
+  equal(Ember.$("#contact", "#qunit-fixture").text(), "Contact", "precond - the link worked");
+
+  equal(hidden, 0, "The link didn't bubble");
+});
+
+test("moves into the named route with context", function() {
+  Router.map(function(match) {
+    this.route("about");
+    this.resource("item", { path: "/item/:id" });
+  });
+
+  Ember.TEMPLATES.about = Ember.Handlebars.compile("<h3>List</h3><ul>{{#each controller}}<li>{{#linkToAnimated item this animations='main:fade'}}{{name}}{{/linkToAnimated}}<li>{{/each}}</ul>{{#linkToAnimated index animations='main:fade' id='home-link'}}Home{{/linkToAnimated}}");
+
+  var people = {
+    yehuda: "Yehuda Katz",
+    tom: "Tom Dale",
+    erik: "Erik Brynroflsson"
+  };
+
+  App.AboutRoute = Ember.Route.extend({
+    model: function() {
+      return Ember.A([
+        { id: "yehuda", name: "Yehuda Katz" },
+        { id: "tom", name: "Tom Dale" },
+        { id: "erik", name: "Erik Brynroflsson" }
+      ]);
+    }
+  });
+
+  App.ItemRoute = Ember.Route.extend({
+    serialize: function(object) {
+      return { id: object.id };
+    },
+
+    deserialize: function(params) {
+      return { id: params.id, name: people[params.id] };
+    }
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/about");
+  });
+
+  equal(Ember.$('h3:contains(List)', '#qunit-fixture').length, 1, "The home template was rendered");
+  equal(normalizeUrl(Ember.$('#home-link').attr('href')), '/', "The home link points back at /");
+
+  Ember.run(function() {
+    Ember.$('li a:contains(Yehuda)', '#qunit-fixture').click();
+  });
+
+  equal(Ember.$('h3:contains(Item)', '#qunit-fixture').length, 1, "The item template was rendered");
+  equal(Ember.$('p', '#qunit-fixture').text(), "Yehuda Katz", "The name is correct");
+
+  Ember.run(function() { Ember.$('#home-link').click(); });
+  Ember.run(function() { Ember.$('#about-link').click(); });
+
+  equal(normalizeUrl(Ember.$('li a:contains(Yehuda)').attr('href')), "/item/yehuda");
+  equal(normalizeUrl(Ember.$('li a:contains(Tom)').attr('href')), "/item/tom");
+  equal(normalizeUrl(Ember.$('li a:contains(Erik)').attr('href')), "/item/erik");
+
+  Ember.run(function() {
+    Ember.$('li a:contains(Erik)', '#qunit-fixture').click();
+  });
+
+  equal(Ember.$('h3:contains(Item)', '#qunit-fixture').length, 1, "The item template was rendered");
+  equal(Ember.$('p', '#qunit-fixture').text(), "Erik Brynroflsson", "The name is correct");
+});
+
+test("binds some anchor html tag common attributes", function() {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkToAnimated index id='self-link' animations='main:fade' title='title-attr'}}Self{{/linkToAnimated}}");
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('#self-link', '#qunit-fixture').attr('title'), 'title-attr', "The self-link contains title attribute");
+});
+
+test("accepts string arguments", function() {
+  Router.map(function() {
+    this.route('filter', { path: '/filters/:filter' });
+  });
+
+  Ember.TEMPLATES.filter = compile('<p>{{filter}}</p>{{#linkToAnimated filter "unpopular" animations="main:fade" id="link"}}Unpopular{{/linkToAnimated}}');
+  Ember.TEMPLATES.index = compile('');
+
+  bootApplication();
+
+  Ember.run(function() { router.handleURL("/filters/popular"); });
+
+  equal(Ember.$('#link', '#qunit-fixture').attr('href'), "/filters/unpopular");
+});
+
+test("unwraps controllers", function() {
+  // The serialize hook is called twice: once to generate the href for the
+  // link and once to generate the URL when the link is clicked.
+  expect(2);
+
+  Router.map(function() {
+    this.route('filter', { path: '/filters/:filter' });
+  });
+
+  var indexObject = { filter: 'popular' };
+
+  App.FilterRoute = Ember.Route.extend({
+    model: function(params) {
+      return indexObject;
+    },
+
+    serialize: function(passedObject) {
+      equal(passedObject, indexObject, "The unwrapped object is passed");
+      return { filter: 'popular' };
+    }
+  });
+
+  App.IndexRoute = Ember.Route.extend({
+    model: function() {
+      return indexObject;
+    }
+  });
+
+  Ember.TEMPLATES.filter = compile('<p>{{filter}}</p>');
+  Ember.TEMPLATES.index = compile('{{#linkToAnimated filter this id="link" animations="main:fade"}}Filter{{/linkToAnimated}}');
+
+  bootApplication();
+
+  Ember.run(function() { router.handleURL("/"); });
+
+  Ember.$('#link', '#qunit-fixture').trigger('click');
+});
+
+test("doesn't change view context", function() {
+  App.IndexView = Ember.View.extend({
+    elementId: 'index',
+    name: 'test'
+  });
+
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("{{view.name}}-{{#linkToAnimated index id='self-link' animations='main:fade'}}Link: {{view.name}}{{/linkToAnimated}}");
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('#index', '#qunit-fixture').text(), 'test-Link: test', "accesses correct view");
+});

--- a/tests/index.html
+++ b/tests/index.html
@@ -22,6 +22,7 @@
 <script src="/tests/helpers.js"></script>
 
 <script src="/tests/animated-container-view.js"></script>
+<script src="/tests/animated-linkto-helper.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Implemented `linkToAnimated` to complement the route transistion API.  To keep the api of `linkTo` and `linkToAnimated` equal, I've implemented a `animations` hook on the route. 

Added text to the README on how to use it. 

Tell me what you think about it.

To do:
- Write some tests to check it
