### PR TITLE
Let views use custom tag names

### DIFF
--- a/src/sass/ember-animated-outlet.scss
+++ b/src/sass/ember-animated-outlet.scss
@@ -6,7 +6,7 @@
     width: 100%;
     @include transform(translate3d(0, 0, 0));
 
-    & > div {
+    & > .ember-view {
         position: absolute;
         top: 0;
         left: 0;


### PR DESCRIPTION
This change lets animated views use a custom tagName, instead of
the default `div`, by using the `.ember-view` class name in the CSS
selector instead of a tag name.
