### PR TITLE
Hide overflow on animated views

### DIFF
--- a/src/sass/ember-animated-outlet.scss
+++ b/src/sass/ember-animated-outlet.scss
@@ -12,6 +12,7 @@
         left: 0;
         width: 100%;
         height: 100%;
+        overflow: hidden;
         @include backface-visibility(hidden);
     }
 }


### PR DESCRIPTION
This change automatically hides the overflow of animated views,
assuming that they do not want to overflow their container.
