### PR TITLE
trigger an event when the animation has been finished

### DIFF
--- a/src/js/animated-container-view.js
+++ b/src/js/animated-container-view.js
@@ -91,6 +91,7 @@ Ember.AnimatedContainerView = Ember.ContainerView.extend({
                             oldView.destroy();
                             //Check to see if there are any queued animations
                             self._isAnimating = false;
+			    $('body').trigger('animated-outlet.animation-finished', [newView]);
                             self._handleAnimationQueue();
                         });
                     });


### PR DESCRIPTION
This is very useful when using animated-outlet on mobile device. , like mentioned in https://github.com/billysbilling/ember-animated-outlet/issues/28 - you can e.g. trigger a customer redraw like this

```
$('body').on('animated-outlet.animation-finished', function(newView){
                                var $var = $('#main-content');
                                $var.hide();
                                $var.get(0).offsetHeight;
                                $var.show();
                                $var.get(0).style.webkitTransform = 'scale(1)';
});
```

To be dicussed:
- alternatives to this approach?
- event-name (namespaced?)
- event-trigger container ( is there a better place then body to start bubbling the event?

Please dont mind the code-styles - i will fix those after the dicussion, this was just a quick "vim go"
