### PR TITLE
Register Library with Ember.libraries

### DIFF
--- a/src/js/animated-container-view.js
+++ b/src/js/animated-container-view.js
@@ -5,6 +5,15 @@
   @namespace Ember
   @extends Ember.ContainerView
 */
+
+(function(){
+  var VERSION = '1.0.0-beta.2';
+  
+  if (Ember.libraries) {
+    Ember.libraries.register('Ember Animated Outlet', VERSION);
+  }
+})();
+
 Ember.AnimatedContainerView = Ember.ContainerView.extend({
 
     classNames: ['ember-animated-container'],


### PR DESCRIPTION
Update to include version number and register in Ember.libraries. It's now visible when using the ember-extension and logged to the console. Small insignificant change, but convenient when trying to keep track of included libraries and versions.
