### PR TITLE
[Bugfix] Changed animation handler to fire only on first didInsertElement

### DIFF
--- a/src/js/animated-container-view.js
+++ b/src/js/animated-container-view.js
@@ -84,7 +84,7 @@ Ember.AnimatedContainerView = Ember.ContainerView.extend({
             if (oldView && effect) {
                 //If an effect is queued, then start the effect when the new view has been inserted in the DOM
                 this._isAnimating = true;
-                newView.on('didInsertElement', function() {
+                newView.one('didInsertElement', function() {
                     Ember.AnimatedContainerView._effects[effect](self, newView, oldView, function() {
                         Em.run(function() {
                             self.removeObject(oldView);


### PR DESCRIPTION
In cases where a view in an animated-outlet triggers a rerender, the transition animation tries to refire since it listens to the didInsertElement. This is likely not intended as we are changing routes and only rerendering the view. Rerendering will then fail. Changing the listener to only fire on the first didInsertElement fixes this issue and is more aligned with the intended effect.
