### PR TITLE
document the right order of arguments to l-t-a

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ you would normally use. You need to give the outlet a name. Example:
 When you want to use the animations from your Handlebars templates, you can use `link-to-animated`. The syntax  for `link-to-animated`is:
 
 ```handlebars
-{{#link-to-animated "invoices.show" animations="main:slideLeft" invoice}}
+{{#link-to-animated "invoices.show" invoice animations="main:slideLeft"}}
 ```
 
 Where:


### PR DESCRIPTION
Documentation only:

Ripping the route name and the model apart leads to a syntax error in handlebars and emblem. Just appending the `animation="foo"` works.

Am using Ember 1.7 btw.
